### PR TITLE
[Minor] Update instruction for API change

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ This is python script that exports emoji from one slack organization and imports
 ### Running Instructions
 
 1. Open a broswer window and open your dev tools network tab
-1. Set a filter of `/api/emoji.list`
+1. Set a filter of `/api/emoji.adminList`
 1. Go to https://YOUR-EMOJI-SOURCE-ORG.slack.com/customize/emoji
 1. You should see one request in your network tab, click it
-1. Copy the `Cookie` request header value into the `sourceSlackOrgCookie` variable value in the script
-1. Copy the `Token` form data value into the  `sourceSlackOrgToken` variable value in the script
+1. Go to the Headers tab Copy the `Cookie` request header value into the `sourceSlackOrgCookie` variable value in the script
+1. Go to the Request tab Copy the `Token` form data value into the  `sourceSlackOrgToken` variable value in the script
 1. Go to https://YOUR-EMOJI-DESTINATION-ORG.slack.com/customize/emoji
 1. You should see one request in your network tab, click it
 1. Copy the `Cookie` request header value into the `destinationSlackOrgCookie` variable value in the script


### PR DESCRIPTION
Confirmed this still works in Nov 2025. But Slack changed its page API to `emoji.adminList` instead.